### PR TITLE
feat: enable defining Metaflow steps across notebook cells with %%step

### DIFF
--- a/metaflow_jupyter.py
+++ b/metaflow_jupyter.py
@@ -1,0 +1,365 @@
+import ast
+import hashlib
+import linecache
+import textwrap
+
+from metaflow.exception import CommandException
+from IPython.core.error import UsageError
+from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
+
+from .metaflow_jupyter_exec import (
+    execute_flow_source,
+)
+from .metaflow_jupyter_flow import (
+    _build_flow_source as _build_flow_source_impl,
+    _parse_run_flow_invocation as _parse_run_flow_invocation_impl,
+    _validate_run_flow_parameter_overrides as _validate_run_flow_parameter_overrides_impl,
+)
+
+from .metaflow_jupyter_step import (
+    DECORATOR_MAGIC_NAMES,
+    MissingImportError,
+    _PreviewSelf,
+    _parse_stacked_decorator_cell as _parse_stacked_decorator_cell_impl,
+    _parse_step_name as _parse_step_name_impl,
+    _register_step_definition as _register_step_definition_impl,
+    _validate_no_inline_step_decorators as _validate_no_inline_step_decorators_impl,
+)
+
+
+STEP_REGISTRY = {}  # {"start": {"decorators": ["@retry(times=1)"], "body": "..."}}
+PARAM_REGISTRY = {}  # {"alpha": {"source": "...", "required": False, "cell_id": "..."}}
+CELL_STEP_OWNERSHIP = {}  # {cell_id: step_name}
+CELL_PARAM_OWNERSHIP = {}  # {cell_id: {"alpha", "epochs"}}
+CURRENT_CELL_ID = None
+ALLOWED_PARAMETER_TYPES = {"str", "int", "float", "bool", "JSONType"}
+PREVIEW_SELF = _PreviewSelf()
+
+
+def _on_pre_run_cell(info):
+    global CURRENT_CELL_ID
+    CURRENT_CELL_ID = getattr(info, "cell_id", None)
+
+
+def _on_post_run_cell(result):
+    global CURRENT_CELL_ID
+    CURRENT_CELL_ID = None
+
+
+def _parse_step_name(step_name_text):
+    return _parse_step_name_impl(step_name_text)
+
+
+def _validate_no_inline_step_decorators(step_name, step_body):
+    return _validate_no_inline_step_decorators_impl(step_name, step_body)
+
+
+def _parse_stacked_decorator_cell(first_decorator_name, first_decorator_args, cell_text):
+    return _parse_stacked_decorator_cell_impl(
+        first_decorator_name,
+        first_decorator_args,
+        cell_text,
+    )
+
+
+def _register_step_definition(shell, step_name, decorators, body):
+    return _register_step_definition_impl(
+        shell,
+        step_name,
+        decorators,
+        body,
+        STEP_REGISTRY,
+        CELL_STEP_OWNERSHIP,
+        PARAM_REGISTRY,
+        CURRENT_CELL_ID,
+        PREVIEW_SELF,
+    )
+
+
+def _is_parameter_call(func_node):
+    return (
+        isinstance(func_node, ast.Name)
+        and func_node.id == "Parameter"
+    ) or (
+        isinstance(func_node, ast.Attribute)
+        and isinstance(func_node.value, ast.Name)
+        and func_node.value.id == "metaflow"
+        and func_node.attr == "Parameter"
+    )
+
+
+def _parse_parameter_type(type_node):
+    if isinstance(type_node, ast.Name):
+        candidate = type_node.id
+    elif (
+        isinstance(type_node, ast.Attribute)
+        and isinstance(type_node.value, ast.Name)
+        and type_node.value.id == "metaflow"
+    ):
+        candidate = type_node.attr
+    else:
+        candidate = None
+
+    if candidate not in ALLOWED_PARAMETER_TYPES:
+        raise UsageError(
+            "Invalid Parameter type. Supported types: str, int, float, bool, JSONType."
+        )
+
+    return candidate
+
+
+def _extract_parameter_spec(assign_node, source_text):
+    if len(assign_node.targets) != 1 or not isinstance(assign_node.targets[0], ast.Name):
+        raise UsageError("%%params supports assignments like: name = Parameter(...).")
+
+    param_name = assign_node.targets[0].id
+    if not param_name.isidentifier():
+        raise UsageError(
+            "Parameter name '%s' must be a valid Python identifier." % param_name
+        )
+
+    value = assign_node.value
+    if not isinstance(value, ast.Call) or not _is_parameter_call(value.func):
+        raise UsageError(
+            "Invalid definition for parameter '%s'. Use: %s = Parameter(...)."
+            % (param_name, param_name)
+        )
+
+    if not value.args:
+        raise UsageError(
+            "Parameter '%s' must include the CLI name as first argument." % param_name
+        )
+
+    first_arg = value.args[0]
+    if not (isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str)):
+        raise UsageError(
+            "Parameter '%s' first argument must be a string literal." % param_name
+        )
+
+    has_default = False
+    has_preview_default = False
+    preview_default = None
+    uses_json_type = False
+    for keyword in value.keywords:
+        if keyword.arg is None:
+            raise UsageError(
+                "Parameter '%s' does not support **kwargs in %%params." % param_name
+            )
+        if keyword.arg == "default":
+            has_default = True
+            try:
+                preview_default = ast.literal_eval(keyword.value)
+                has_preview_default = True
+            except (SyntaxError, ValueError):
+
+                has_preview_default = False
+                preview_default = None
+        elif keyword.arg == "type":
+            parsed_type = _parse_parameter_type(keyword.value)
+            if parsed_type == "JSONType":
+                uses_json_type = True
+
+    source = ast.get_source_segment(source_text, assign_node)
+    if source is None:
+        source = ast.unparse(assign_node)
+
+    return {
+        "name": param_name,
+        "source": source.strip(),
+        "required": not has_default,
+        "has_preview_default": has_preview_default,
+        "preview_default": preview_default,
+        "uses_json_type": uses_json_type,
+    }
+
+
+def _parse_params_cell(cell_text):
+    body = textwrap.dedent(cell_text).strip("\n")
+    if not body.strip():
+        raise UsageError("%%params cell cannot be empty.")
+
+    try:
+        parsed = ast.parse(body)
+    except SyntaxError as e:
+        raise UsageError("Invalid syntax in %%params: %s" % e.msg) from e
+
+    specs = []
+    seen = set()
+    for stmt in parsed.body:
+        if not isinstance(stmt, ast.Assign):
+            raise UsageError(
+                "%%params only supports Parameter assignments like: alpha = Parameter(...)."
+            )
+        spec = _extract_parameter_spec(stmt, body)
+        if spec["name"] in seen:
+            raise UsageError(
+                "Duplicate parameter name '%s' in %%params cell." % spec["name"]
+            )
+        seen.add(spec["name"])
+        specs.append(spec)
+
+    return specs
+
+
+def _register_param_definitions(shell, param_specs):
+    incoming_cell_id = CURRENT_CELL_ID
+    owned_param_names = set()
+    if incoming_cell_id:
+        owned_param_names = set(CELL_PARAM_OWNERSHIP.get(incoming_cell_id, set()))
+
+    effective_registry = {
+        name: definition
+        for name, definition in PARAM_REGISTRY.items()
+        if name not in owned_param_names
+    }
+
+    for spec in param_specs:
+        existing_definition = effective_registry.get(spec["name"])
+        if existing_definition is None:
+            continue
+
+        existing_cell_id = existing_definition.get("cell_id")
+        if incoming_cell_id and existing_cell_id:
+            if incoming_cell_id != existing_cell_id:
+                raise UsageError(
+                    "Duplicate parameter name '%s'. Parameter is already owned by another cell."
+                    % spec["name"]
+                )
+        elif (
+            existing_definition.get("source") != spec["source"]
+            or bool(existing_definition.get("required")) != spec["required"]
+            or bool(existing_definition.get("has_preview_default"))
+            != spec["has_preview_default"]
+            or bool(existing_definition.get("uses_json_type"))
+            != spec["uses_json_type"]
+        ):
+            raise UsageError(
+                "Duplicate parameter name '%s'. A different definition is already "
+                "registered for this parameter." % spec["name"]
+            )
+
+    if incoming_cell_id:
+        for param_name in owned_param_names:
+            existing = PARAM_REGISTRY.get(param_name)
+            if existing and existing.get("cell_id") == incoming_cell_id:
+                PARAM_REGISTRY.pop(param_name, None)
+        CELL_PARAM_OWNERSHIP.pop(incoming_cell_id, None)
+
+    new_owned_names = set()
+    for spec in param_specs:
+        existing_definition = PARAM_REGISTRY.get(spec["name"])
+        stored_cell_id = None
+        if incoming_cell_id:
+            stored_cell_id = incoming_cell_id
+        elif existing_definition is not None:
+            stored_cell_id = existing_definition.get("cell_id")
+
+        PARAM_REGISTRY[spec["name"]] = {
+            "source": spec["source"],
+            "required": spec["required"],
+            "has_preview_default": spec["has_preview_default"],
+            "preview_default": spec["preview_default"],
+            "uses_json_type": spec["uses_json_type"],
+            "cell_id": stored_cell_id,
+        }
+        if incoming_cell_id and stored_cell_id == incoming_cell_id:
+            new_owned_names.add(spec["name"])
+
+    if incoming_cell_id:
+        CELL_PARAM_OWNERSHIP[incoming_cell_id] = new_owned_names
+
+    print("Stored params: %s" % ", ".join(spec["name"] for spec in param_specs))
+
+
+def _parse_run_flow_invocation(line):
+    return _parse_run_flow_invocation_impl(line)
+
+
+def _validate_run_flow_parameter_overrides(param_overrides):
+    return _validate_run_flow_parameter_overrides_impl(param_overrides, PARAM_REGISTRY)
+
+
+def _build_flow_source(flow_name):
+    return _build_flow_source_impl(flow_name, STEP_REGISTRY, PARAM_REGISTRY)
+
+
+def _build_flow_class(flow_name):
+    flow_source = _build_flow_source(flow_name)
+    source_hash = hashlib.sha1(flow_source.encode("utf-8")).hexdigest()[:12]
+    source_filename = "<metaflow_jupyter:%s:%s>" % (flow_name, source_hash)
+
+    source_lines = flow_source.splitlines(True)
+    if not source_lines or not source_lines[-1].endswith("\n"):
+        source_lines.append("\n")
+    linecache.cache[source_filename] = (
+        len(flow_source),
+        None,
+        source_lines,
+        source_filename,
+    )
+
+    module_name = "_metaflow_jupyter_%s_%s" % (flow_name.lower(), source_hash)
+    namespace = {"__name__": module_name}
+    compiled = compile(flow_source, source_filename, "exec")
+    exec(compiled, namespace, namespace)
+    flow_cls = namespace.get(flow_name)
+    if flow_cls is None:
+        raise CommandException(
+            "Flow source did not define class '%s'." % flow_name
+        )
+    return flow_cls
+
+
+def _make_decorator_magic(decorator_name):
+    def _decorator_magic(self, line, cell):
+        self._handle_decorator_magic(decorator_name, line, cell)
+
+    _decorator_magic.__name__ = decorator_name
+    return cell_magic(_decorator_magic)
+
+
+@magics_class
+class MetaflowJupyterMagics(Magics):
+    def _handle_decorator_magic(self, decorator_name, line, cell):
+        step_name, decorators, body = _parse_stacked_decorator_cell(
+            decorator_name,
+            line,
+            cell,
+        )
+        _register_step_definition(self.shell, step_name, decorators, body)
+
+    @cell_magic
+    def step(self, line, cell):
+        name = _parse_step_name(line)
+        body = _validate_no_inline_step_decorators(name, cell)
+        _register_step_definition(self.shell, name, [], body)
+
+    @cell_magic
+    def params(self, line, cell):
+        if line.strip():
+            raise UsageError("Usage: %%params")
+        param_specs = _parse_params_cell(cell)
+        _register_param_definitions(self.shell, param_specs)
+
+    for _decorator_name in DECORATOR_MAGIC_NAMES:
+        locals()[_decorator_name] = _make_decorator_magic(_decorator_name)
+    del _decorator_name
+
+    @line_magic
+    def run_flow(self, line):
+        try:
+            flow_name, param_overrides = _parse_run_flow_invocation(line)
+            _validate_run_flow_parameter_overrides(param_overrides)
+            flow_source = _build_flow_source(flow_name)
+        except CommandException as e:
+            raise UsageError(str(e)) from e
+
+        return execute_flow_source(flow_name, flow_source, param_overrides)
+
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(MetaflowJupyterMagics)
+    events = getattr(ipython, "events", None)
+    if events is not None:
+        events.register("pre_run_cell", _on_pre_run_cell)
+        events.register("post_run_cell", _on_post_run_cell)

--- a/metaflow_jupyter_exec.py
+++ b/metaflow_jupyter_exec.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+import threading
+from queue import Queue, Empty
+
+from metaflow import Runner
+
+
+def execute_flow_source(flow_name, flow_source, param_overrides, base_dir=None):
+    if base_dir is None:
+        base_dir = os.getcwd()
+
+    runner = None
+    flow_file_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix=flow_name,
+            suffix=".py",
+            mode="w",
+            dir=base_dir,
+            delete=False,
+        ) as tmp_flow_file:
+            tmp_flow_file.write(flow_source)
+            tmp_flow_file.flush()
+            flow_file_path = tmp_flow_file.name
+
+        env = os.environ.copy()
+        env["JPY_PARENT_PID"] = ""
+
+        runner = Runner(
+            flow_file=flow_file_path,
+            show_output=True,
+            env=env,
+            cwd=base_dir,
+        )
+        result = runner.run(**param_overrides)
+        return result.run
+    finally:
+        if runner is not None:
+            runner.cleanup()
+        if flow_file_path and os.path.exists(flow_file_path):
+            os.unlink(flow_file_path)

--- a/metaflow_jupyter_flow.py
+++ b/metaflow_jupyter_flow.py
@@ -1,0 +1,147 @@
+import ast
+import shlex
+
+from metaflow.exception import CommandException
+
+from .metaflow_jupyter_step import (
+    _extract_next_step_targets,
+    _extract_step_decorator_name,
+    _indent_with_spaces,
+    validate_step_body_before_exec,
+)
+
+
+def _parse_run_flow_invocation(line):
+    try:
+        tokens = shlex.split(line)
+    except ValueError as e:
+        raise CommandException("Invalid %run_flow arguments: %s" % e) from e
+
+    if not tokens:
+        raise CommandException("Usage: %run_flow <FlowName>")
+
+    flow_name = tokens[0]
+    overrides = {}
+    for token in tokens[1:]:
+        if "=" not in token:
+            raise CommandException(
+                "Invalid parameter override '%s'. Use key=value." % token
+            )
+        key, raw_value = token.split("=", 1)
+        if not key or not key.isidentifier():
+            raise CommandException(
+                "Invalid parameter name '%s' in %run_flow overrides." % key
+            )
+        if key in overrides:
+            raise CommandException(
+                "Duplicate parameter override '%s' in %run_flow." % key
+            )
+        try:
+            overrides[key] = ast.literal_eval(raw_value)
+        except (SyntaxError, ValueError):
+            overrides[key] = raw_value
+
+    return flow_name, overrides
+
+
+def _validate_run_flow_parameter_overrides(param_overrides, param_registry):
+    unknown = sorted(
+        param_name for param_name in param_overrides if param_name not in param_registry
+    )
+    if unknown:
+        raise CommandException("Unknown parameter override(s): %s" % ", ".join(unknown))
+
+    missing_required = sorted(
+        param_name
+        for param_name, definition in param_registry.items()
+        if definition.get("required") and param_name not in param_overrides
+    )
+    if missing_required:
+        raise CommandException(
+            "Missing required parameter override(s) in %%run_flow: %s"
+            % ", ".join(missing_required)
+        )
+
+
+def _build_flow_source(flow_name, step_registry, param_registry):
+    if not flow_name or not flow_name.isidentifier():
+        raise CommandException("Usage: %run_flow <FlowName>")
+
+    if not step_registry:
+        raise CommandException("No steps found. Add steps using %%step <step_name>.")
+
+    if "start" not in step_registry:
+        raise CommandException("Missing required step 'start'.")
+    if "end" not in step_registry:
+        raise CommandException("Missing required step 'end'.")
+
+    step_specs = []
+    used_step_decorators = set()
+
+    for step_name, step_data in step_registry.items():
+        if not step_name.isidentifier():
+            raise CommandException("Invalid step name: %s" % step_name)
+
+        step_decorators = []
+        step_body = step_data
+        if isinstance(step_data, dict):
+            step_decorators = step_data.get("decorators") or []
+            step_body = step_data.get("body", "")
+
+        for decorator_line in step_decorators:
+            decorator_name = _extract_step_decorator_name(step_name, decorator_line)
+            used_step_decorators.add(decorator_name)
+
+        body = validate_step_body_before_exec(step_name, step_body)
+        if not body.strip():
+            body = "pass"
+
+        next_targets = _extract_next_step_targets(step_name, body)
+        step_specs.append((step_name, step_decorators, body, next_targets))
+
+    step_index = {name: idx for idx, (name, _, _, _) in enumerate(step_specs)}
+    for step_name, _, _, next_targets in step_specs:
+        for target_name in next_targets:
+            if target_name not in step_index:
+                raise CommandException(
+                    "Step '%s' references unknown step '%s' in self.next(...)."
+                    % (step_name, target_name)
+                )
+            if step_index[target_name] <= step_index[step_name]:
+                raise CommandException(
+                    "Step '%s' references previous step '%s' in self.next(...). "
+                    "Steps must transition to steps defined later in the flow."
+                    % (step_name, target_name)
+                )
+
+    used_parameter_imports = set()
+    if param_registry:
+        used_parameter_imports.add("Parameter")
+        if any(spec.get("uses_json_type") for spec in param_registry.values()):
+            used_parameter_imports.add("JSONType")
+
+    import_items = ["FlowSpec", "step"] + sorted(
+        used_step_decorators | used_parameter_imports
+    )
+    parts = [
+        "from metaflow import %s" % ", ".join(import_items),
+        "",
+        "class %s(FlowSpec):" % flow_name,
+    ]
+
+    for param_spec in param_registry.values():
+        parts.extend(["", _indent_with_spaces(param_spec["source"], 4)])
+
+    for step_name, step_decorators, body, _ in step_specs:
+        parts.extend([""])
+        parts.extend("    %s" % deco for deco in step_decorators)
+        parts.extend(
+            [
+                "    @step",
+                "    def %s(self):" % step_name,
+                _indent_with_spaces(body, 8),
+            ]
+        )
+
+    parts.extend(["", "if __name__ == '__main__':", "    %s()" % flow_name])
+    return ("\n".join(parts)).rstrip() + "\n"

--- a/metaflow_jupyter_step.py
+++ b/metaflow_jupyter_step.py
@@ -1,0 +1,352 @@
+import ast
+import copy
+import textwrap
+
+try:
+    from IPython.core.error import UsageError
+except ImportError:
+    class UsageError(Exception):
+        pass
+
+
+DECORATOR_MAGIC_NAMES = ("environment","batch","card","catch","conda","pypi",
+                         "kubernetes","resources","retry","secrets","timeout")
+ALLOWED_STEP_DECORATORS = set(DECORATOR_MAGIC_NAMES)
+
+
+class MissingImportError(UsageError):
+    pass
+
+# provides a fake self so code like self.x = ... can run safely.
+class _PreviewSelf(object):
+    def next(self, *args, **kwargs):
+        return None
+
+
+# In preview mode, execute the cell quickly without running the whole flow.
+# Removes self.next(...) so no graph transition happens.
+class _StripNextCalls(ast.NodeTransformer):
+    def visit_Call(self, node):
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+            and node.func.attr == "next"
+        ):
+            return ast.Constant(value=None)
+        return self.generic_visit(node)
+
+
+def _indent_with_spaces(block, spaces):
+    prefix = " " * spaces
+    return "\n".join((prefix + line if line else prefix) for line in block.splitlines())
+
+
+def _parse_step_name(step_name_text):
+    step_name = step_name_text.strip()
+    if not step_name:
+        raise UsageError("Usage: %%step <step_name>")
+    if not step_name.isidentifier():
+        raise UsageError("Step name must be a valid Python identifier")
+    return step_name
+
+
+def _parse_step_body(step_name, step_body):
+    body = textwrap.dedent(step_body).strip("\n")
+    try:
+        parsed_body = ast.parse(body)
+    except SyntaxError as e:
+        raise UsageError("Invalid syntax in step '%s': %s" % (step_name, e.msg)) from e
+    return body, parsed_body
+
+
+def validate_self_next(node):
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "next"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+    )
+
+def validate_self_next_argument(node):
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+        and node.attr.isidentifier()
+    )
+
+def validate_step_body_before_exec(step_name, step_body):
+    body, parsed_body = _parse_step_body(step_name, step_body)
+
+    if step_name != "end":
+        has_top_level_next_call = any(
+            isinstance(stmt, ast.Expr) and validate_self_next(stmt.value)
+            for stmt in parsed_body.body
+        )
+        if not has_top_level_next_call:
+            raise UsageError("Step '%s' is missing self.next(...)." % step_name)
+
+        last_stmt = parsed_body.body[-1] if parsed_body.body else None
+        if not (isinstance(last_stmt, ast.Expr) and validate_self_next(last_stmt.value)):
+            raise UsageError(
+                "Step '%s' must end with self.next(...). No code can appear "
+                "after self.next(...)." % step_name
+            )
+
+        next_call = last_stmt.value
+        if not next_call.args or not all(
+            validate_self_next_argument(arg) for arg in next_call.args
+        ):
+            raise UsageError(
+                "Step '%s' has invalid self.next(...). Use self.next(self.<next_step>) "
+                "with one or more step references." % step_name
+            )
+
+    return body
+
+
+def _extract_next_step_targets(step_name, step_body):
+    if step_name == "end":
+        return []
+
+    _, parsed_body = _parse_step_body(step_name, step_body)
+    if not parsed_body.body:
+        return []
+
+    last_stmt = parsed_body.body[-1]
+    if not (isinstance(last_stmt, ast.Expr) and validate_self_next(last_stmt.value)):
+        return []
+
+    return [
+        arg.attr for arg in last_stmt.value.args if validate_self_next_argument(arg)
+    ]
+
+
+def _validate_no_inline_step_decorators(step_name, step_body):
+    body = textwrap.dedent(step_body).strip("\n")
+    if not body:
+        return body
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("@"):
+            raise UsageError(
+                "Inline decorators are not supported in %%%%step '%s'. "
+                "Use %%%%retry / %%%%batch style decorator magics before %%%%step." % step_name
+            )
+        break
+    return body
+
+
+def _parse_decorator_magic_arguments(decorator_name, raw_args):
+    args_text = raw_args.strip()
+    if not args_text:
+        return ""
+
+    try:
+        call_node = ast.parse("f(%s)" % args_text, mode="eval").body
+    except SyntaxError as e:
+        raise UsageError("Invalid arguments for %%%s: %s" % (decorator_name, e.msg)) from e
+
+    if not isinstance(call_node, ast.Call):
+        raise UsageError(
+            "Invalid arguments for %%%s. Use keyword arguments like: "
+            "%%%s key=value" % (decorator_name, decorator_name)
+        )
+    if call_node.args:
+        raise UsageError(
+            "Decorator magic %%%s supports keyword arguments only." % decorator_name
+        )
+    if any(keyword.arg is None for keyword in call_node.keywords):
+        raise UsageError("Decorator magic %%%s does not support **kwargs." % decorator_name)
+
+    return ", ".join(
+        "%s=%s" % (keyword.arg, ast.unparse(keyword.value)) for keyword in call_node.keywords
+    )
+
+
+def _decorator_magic_to_source(decorator_name, raw_args):
+    if decorator_name not in ALLOWED_STEP_DECORATORS:
+        raise UsageError("Unknown decorator magic '%%%%%s'." % decorator_name)
+
+    normalized_args = _parse_decorator_magic_arguments(decorator_name, raw_args)
+    if not normalized_args:
+        return "@%s" % decorator_name
+    return "@%s(%s)" % (decorator_name, normalized_args)
+
+
+def _extract_step_decorator_name(step_name, decorator_line):
+    if not decorator_line.startswith("@"):
+        raise UsageError(
+            "Invalid decorator syntax in step '%s': '%s'" % (step_name, decorator_line)
+        )
+
+    decorator_expr = decorator_line[1:].strip()
+    if not decorator_expr:
+        raise UsageError(
+            "Invalid decorator syntax in step '%s': '%s'" % (step_name, decorator_line)
+        )
+
+    try:
+        parsed_expr = ast.parse(decorator_expr, mode="eval")
+    except SyntaxError as e:
+        raise UsageError(
+            "Invalid decorator syntax in step '%s': %s" % (step_name, e.msg)
+        ) from e
+
+    deco_node = parsed_expr.body
+    if isinstance(deco_node, ast.Call):
+        deco_node = deco_node.func
+
+    if isinstance(deco_node, ast.Name):
+        decorator_name = deco_node.id
+    elif isinstance(deco_node, ast.Attribute):
+        decorator_name = deco_node.attr
+    else:
+        raise UsageError(
+            "Invalid decorator syntax in step '%s': '%s'" % (step_name, decorator_line)
+        )
+
+    if decorator_name == "step":
+        raise UsageError(
+            "Do not use @step inside %%step '%s'. @step is added automatically." % step_name
+        )
+
+    if decorator_name not in ALLOWED_STEP_DECORATORS:
+        raise UsageError(
+            "Unknown step decorator '%s' in step '%s'." % (decorator_name, step_name)
+        )
+
+    return decorator_name
+
+
+def _parse_stacked_decorator_cell(first_decorator_name, first_decorator_args, cell_text):
+    decorator_lines = [
+        _decorator_magic_to_source(first_decorator_name, first_decorator_args)
+    ]
+    lines = textwrap.dedent(cell_text).splitlines()
+    idx = 0
+
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if not stripped:
+            idx += 1
+            continue
+
+        if not stripped.startswith("%%"):
+            raise UsageError("Decorator magics must be followed by %%step <step_name>.")
+
+        magic_line = stripped[2:].strip()
+        if not magic_line:
+            raise UsageError("Invalid magic syntax: '%s'" % stripped)
+
+        parts = magic_line.split(None, 1)
+        magic_name = parts[0]
+        magic_args = parts[1] if len(parts) > 1 else ""
+
+        if magic_name == "step":
+            step_name = _parse_step_name(magic_args)
+            body = "\n".join(lines[idx + 1 :]).strip("\n")
+            return step_name, decorator_lines, body
+
+        if magic_name not in ALLOWED_STEP_DECORATORS:
+            raise UsageError("Unknown decorator magic '%%%%%s'." % magic_name)
+
+        decorator_lines.append(_decorator_magic_to_source(magic_name, magic_args))
+        idx += 1
+
+    raise UsageError("Decorator magics must include %%step <step_name>.")
+
+
+def _execute_step_preview(shell, step_name, step_body, param_registry, preview_self):
+    body, parsed_body = _parse_step_body(step_name, step_body)
+    if not body.strip():
+        return
+
+    preview_tree = _StripNextCalls().visit(parsed_body)
+    ast.fix_missing_locations(preview_tree)
+    preview_code = compile(preview_tree, "<metaflow-step-preview>", "exec")
+
+    for param_name, param_spec in param_registry.items():
+        if param_spec.get("has_preview_default"):
+            try:
+                value = copy.deepcopy(param_spec.get("preview_default"))
+            except Exception:
+                value = param_spec.get("preview_default")
+        else:
+            value = None
+        setattr(preview_self, param_name, value)
+
+    namespace = {"__builtins__": __builtins__, "self": preview_self}
+    try:
+        exec(preview_code, namespace, namespace)
+    except NameError as e:
+        # Step previews run in an isolated namespace so every dependency must
+        # be imported/defined in the same cell. Missing names are treated as
+        # missing imports to make notebook behavior explicit and deterministic.
+        message = str(e)
+        if message.startswith("name '") and "' is not defined" in message:
+            missing_name = message.split("name '", 1)[1].split("' is not defined", 1)[0]
+            raise MissingImportError(
+                "Missing import in step '%s': '%s' is not defined. "
+                "Add the import/definition in this %%step cell."
+                % (step_name, missing_name)
+            ) from e
+        raise
+
+
+def _register_step_definition(
+    shell, step_name, decorators, body, step_registry, 
+    cell_step_ownership, param_registry, current_cell_id,preview_self,
+):
+    validated_body = validate_step_body_before_exec(step_name, body)
+    incoming_cell_id = current_cell_id
+    if incoming_cell_id:
+        owned_step_name = cell_step_ownership.get(incoming_cell_id)
+        if owned_step_name and owned_step_name != step_name:
+            owned_step = step_registry.get(owned_step_name)
+            if owned_step and owned_step.get("cell_id") == incoming_cell_id:
+                step_registry.pop(owned_step_name, None)
+            cell_step_ownership.pop(incoming_cell_id, None)
+
+    existing_definition = step_registry.get(step_name)
+    if existing_definition is not None:
+        existing_cell_id = existing_definition.get("cell_id")
+        existing_decorators = existing_definition.get("decorators") or []
+        existing_body = textwrap.dedent(existing_definition.get("body", "")).strip("\n")
+
+        if incoming_cell_id and existing_cell_id:
+            if incoming_cell_id != existing_cell_id:
+                raise UsageError(
+                    "Duplicate step name '%s'. Step is already owned by another cell." % step_name
+                )
+        elif existing_decorators != decorators or existing_body != validated_body:
+            raise UsageError(
+                "Duplicate step name '%s'. A different definition is already "
+                "registered for this step name." % step_name
+            )
+
+    _execute_step_preview(shell, step_name, validated_body, param_registry, preview_self)
+    is_update = existing_definition is not None
+    stored_cell_id = None
+    if incoming_cell_id:
+        stored_cell_id = incoming_cell_id
+    elif existing_definition is not None:
+        stored_cell_id = existing_definition.get("cell_id")
+
+    step_registry[step_name] = {
+        "decorators": decorators,
+        "body": validated_body,
+        "cell_id": stored_cell_id,
+    }
+    if stored_cell_id:
+        cell_step_ownership[stored_cell_id] = step_name
+
+    if is_update:
+        print("Updated step: %s" % step_name)
+    else:
+        print("Stored step: %s" % step_name)


### PR DESCRIPTION
## PR Type
- [x] New feature

## Summary
This PR adds four new files that implement the new %%step magic cell that allows a notebook user to split a flow into multiple cells. These files would go inside the runner folder we have in the metaflow codebase.

## Issue
Fixes [#2](https://github.com/npow/metaflow-jupyter/issues/2)

I left all the details of my implementation in the comments of the issue

## Reproduction
**Runtime:** Python 3.13.4 / macOS 15.3.1 (Darwin 24.3.0, build 24D70)
What tests should I add for this feature?

## Changes Made
- Added `metaflow_jupyter.py` which implements the notebook IPython extension surface for flow authoring magics (%%step, decorator magics, %%params, %run_flow), plus shared in-memory registries and helper wrappers.
- Added `metaflow_jupyter_step.py` which implements step parsing and validation logic, decorator parsing, self.next() target extraction, and preview-time step registration behavior.
- Added `metaflow_jupyter_flow.py` which implements flow source generation and validation, converting registered notebook steps/params into a generated `FlowSpec` class.
- Added `metaflow_jupyter_exec.py` which implements execution plumbing to materialize generated flow source into a temporary file, run it through `metaflow.Runner`, return a `Run`, and clean up temporary artifacts.


## AI Tool Usage
- [x] AI tools were used

I used GPT-5.3-Codex for writing/refining the code.
I reviewed, understood, and tested all the code.

## Acceptance Criteria (MVP)
- [x] `%%step` registers step definitions from multiple cells
- [x] `%run_flow` assembles and executes a valid Metaflow flow
- [x] Works in Jupyter and IPython
- [x] Clear errors for missing `self.next()`, duplicate step names, etc.
- [x] Returns a `Run` object for artifact access

If you have any feedback please let me know.